### PR TITLE
feat(data): implement TaskRepository with Room (TaskDao + mapper)

### DIFF
--- a/data/src/main/kotlin/com/nazam/todo_clean_architecture/data/repository/TaskRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/nazam/todo_clean_architecture/data/repository/TaskRepositoryImpl.kt
@@ -1,0 +1,42 @@
+package com.nazam.todo_clean_architecture.data.repository
+
+import com.nazam.todo_clean_architecture.data.local.dao.TaskDao
+import com.nazam.todo_clean_architecture.data.mapper.toDomain
+import com.nazam.todo_clean_architecture.data.mapper.toEntity
+import com.nazam.todo_clean_architecture.domain.model.Task
+import com.nazam.todo_clean_architecture.domain.repository.TaskRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class TaskRepositoryImpl (
+    private val dao: TaskDao
+): TaskRepository {
+
+    override fun observeTasks(): Flow<List<Task>> {
+        return dao.observeAll().map { entities ->
+            entities.toDomain()
+        }
+    }
+
+    override suspend fun getById(id: Int): Task? {
+        return dao.getById(id)?.toDomain()
+    }
+
+    override suspend fun add(task: Task): Long {
+        return dao.insert(task.toEntity())
+    }
+
+    override suspend fun update(task: Task) {
+        dao.update(task.toEntity())
+    }
+
+    override suspend fun delete(id: Int) {
+        dao.deleteById(id)
+    }
+
+    override fun search(query: String): Flow<List<Task>> {
+        return dao.search(query).map { entities ->
+            entities.toDomain()
+        }
+    }
+}


### PR DESCRIPTION
What’s new?

	•	Implemented TaskRepositoryImpl in the data layer
	•	Connected TaskDao and TaskMapper to fulfill the TaskRepository interface from domain
	•	Added support for:
	•	Observing tasks (Flow)
	•	Getting a task by ID
	•	Adding a new task (insert)
	•	Updating an existing task
	•	Deleting a task by ID
	•	Searching tasks by title

Why?

This PR completes the repository layer by providing a concrete implementation (TaskRepositoryImpl) that bridges the domain and data layers.
It allows the domain use cases (AddTaskUseCase, GetTasksUseCase, etc.) to interact with Room database through a clean abstraction.

Impact

	•	The domain layer can now use TaskRepository without knowing anything about Room.
	•	Prepares the app layer (presentation) to integrate with Hilt for dependency injection.