### PR TITLE
feat(app): add TodoApplication as Hilt entry point

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".TodoApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/nazam/todo_clean_architecture/TodoApplication.kt
+++ b/app/src/main/java/com/nazam/todo_clean_architecture/TodoApplication.kt
@@ -1,0 +1,10 @@
+package com.nazam.todo_clean_architecture
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+/**
+ * Classe Application principale.
+ * Point d'entrée pour Hilt (injection de dépendances).
+ */
+@HiltAndroidApp
+class TodoApplication : Application()

--- a/app/src/main/java/com/nazam/todo_clean_architecture/di/AppModule.kt
+++ b/app/src/main/java/com/nazam/todo_clean_architecture/di/AppModule.kt
@@ -1,0 +1,4 @@
+package com.nazam.todo_clean_architecture.di
+
+class AppModule {
+}


### PR DESCRIPTION
What’s new?

	•	Added TodoApplication class annotated with @HiltAndroidApp
	•	Updated AndroidManifest.xml to register TodoApplication as the application entry point

Why?

This is required to enable Hilt dependency injection across the app.
TodoApplication acts as the root container where Hilt initializes its dependency graph.

Impact

	•	Hilt is now properly initialized at app startup
	•	Makes dependency injection available in activities, fragments, and viewmodels
	•	Prepares the app for future integrations with Room, Repository, and UseCases